### PR TITLE
Change distance state in perturbation norm metric to single float

### DIFF
--- a/library/src/charmory/metrics/perturbation.py
+++ b/library/src/charmory/metrics/perturbation.py
@@ -35,7 +35,7 @@ class PerturbationNormMetric(Metric):
         self.total: torch.Tensor
         self.add_state(
             "distance",
-            default=torch.tensor(0, dtype=torch.float64),
+            default=torch.tensor(0, dtype=torch.float32),
             dist_reduce_fx="sum",
         )
         self.add_state("total", default=torch.tensor(0), dist_reduce_fx="sum")


### PR DESCRIPTION
Change distance state in perturbation norm metric to single float precision for compatibility with PyTorch MPS backend.