### PR TITLE
Fix CI chdir and add back jatic_toolbox reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,14 @@ jobs:
 
       - name: Build wheels
         run: |
+          hatch build --clean --target wheel                 # armory-suite
           cd library && hatch build --clean --target wheel
-          cd examples && hatch build --clean --target wheel
+          cd ../examples && hatch build --clean --target wheel
 
+      # there is no point in using the pypi-publish action, since we need to publish
+      # multiple wheels  and this is just too easy as it is
       - name: Upload wheels to PyPI
         run: |
+           hatch publish --user __token__ --auth ${{ secrets.PYPI_PUBLISH_TOKEN }} # armory-suite
            cd library && hatch publish --user __token__ --auth ${{ secrets.PYPI_PUBLISH_TOKEN }}
-           cd examples && hatch publish --user __token__ --auth ${{ secrets.PYPI_PUBLISH_TOKEN }}
+           cd ../examples && hatch publish --user __token__ --auth ${{ secrets.PYPI_PUBLISH_TOKEN }}

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -26,12 +26,9 @@ huggingface = [
     "transformers",
 ]
 
-# pypi will not accept this dependency because it is not a public repo therefore I'm
-# just pulling it for at least the time needed to publish armory-examples thus aquiring
-# the package name
-#
-# jatic = [ "jatic_toolbox @
-#     git+ssh://git@gitlab.jatic.net/jatic/cdao/jatic-toolbox.git@v0.2.0rc1", ]
+jatic = [
+    "jatic_toolbox @ git+ssh://git@gitlab.jatic.net/jatic/cdao/jatic-toolbox.git@v0.2.0rc1",
+]
 
 yolo = [
     "yolov5",


### PR DESCRIPTION
There's a minor cart-horse ordering issue here.

To publish armory-examples v23.11.1, I had to pull out the gitlab.jatic private repo reference for jatic_toolbox.

If we merge this PR, it will break further CI because of the invalid private dependency. But, because a goodly number of examples use jatic_toolbox, leaving it out makes `pip install examples` fail to work.

The workaround is to
```
pip install examples[all]
pip install git+ssh://git@gitlab.jatic.net/jatic/cdao/jatic-toolbox.git@v0.2.0rc1
```

I'd like to figure out what's best in Confab.