### PR TITLE
removed unreference requirements

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -28,10 +28,6 @@ dependencies = [
     "ffmpeg-python",                            # Needed for armory.utils.export
     "pydub",                                    # this is in ART's extra-requires
     "tidecv",                                   # Needed for TIDE metrics
-    # Both `opencv-python` and `opencv-python-headless` must specify
-    # the same version.
-    "opencv-python == 4.5.5.62",          # Needed for CARLA baseline scenario
-    "opencv-python-headless == 4.5.5.62", # Needed for CARLA baseline scenario
     "tensorboardx",
 
     # math


### PR DESCRIPTION
We had unreferenced requirements for opencv* that came from CARLA. We dropped CARLA support as a GARD legacy but didn't clean up the imports.

JATIC common asked if we needed the pin, and we responded we didn't need the packages at all.