### PR TITLE
force a PyYAML version to clear MacOS install bug

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -51,6 +51,13 @@ dependencies = [
 
     # metrics
     "transformers",
+
+    # an ugly hack to workaround a bug on MacOS which makes PyYAML 5.4.1 unbuildable
+    # lightning 2.1.2 requires PyYAML >= 5.4 < 8.0 which on MacOS under Python 3.11
+    # somehow resolves to 5.4.1 which doesn't build. Let's try forcing a version
+    # and see if it helps. I'd like to do this as a constraints.txt entry but
+    # constraints and --editable are mutually exclusive.
+    "PyYAML >= 6",
 ]
 
 


### PR DESCRIPTION
There are multiple indirect requirements for PyYAML through dependencies of armory library including a peculiar spec from `lightning`:

    PyYAML required: >=5.4,<8.0

where PyYAML 6 only recently came out and 8.0 might never exist. Somehow the pip 3.11 (and 3.9) resolvers on MacOS really want to install PyYAML 5.4.1 and that cannot build on MacOS for some reason that I've not bothered to debug.

Because my Linux system happily resolves the dependencies to PyYAML 6.0.1, I'd like to force that with a `constraints.txt` file **but** constraints and `--editable` are [mutually exclusive according to pip](https://pip.pypa.io/en/stable/user_guide/#constraints-files). So, this is the workaround.

Here is a pipdeptree for reference:  [pipdep.txt](https://github.com/twosixlabs/armory-library/files/13516529/pipdep.txt)
