### PR TITLE
run build and test nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - master
 
+  schedule:
+    # run this every day at 7:20am UTC
+    - cron: '20 7 * * *'
+
 jobs:
   code-linting:
     name: 🧹 Code Linting


### PR DESCRIPTION
The hatchling builder changed on us and faulted on making an empty armory-suite package.

Our CI would have caught that if it ran nightly.