### PR TITLE
pin hatchling version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+
+# hatchling 1.19 prevents installation of a pyproject with no files included
+# because this package currently has no files, but does include helpful
+# dependencies and scripts, we had to pin to 1.19 on 12-dec-2023 as a
+# workaround. This can possibly be unpinned in the furture.
+# cf. https://github.com/pypa/hatch/issues/1113
+requires = ["hatchling<=1.18.0"]
 
 
 [project]


### PR DESCRIPTION
because of https://github.com/pypa/hatch/issues/1113 with no better workaround apparent

Alternatives like 
```
include = ['docs']
```
put junk into the `site-packages` directory.