### PR TITLE
unpin torchmetrics

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pydub",                                    # this is in ART's extra-requires
     "tidecv",                                   # Needed for TIDE metrics
     "tensorboardx",
+    "torchmetrics",
 
     # math
     "scikit-learn < 1.2.0", # ART requires scikit-learn >= 0.22.2, < 1.2.0
@@ -75,7 +76,6 @@ armory-mlflow-server = "charmory.track:server"
 extras = [
     # deepspeech
     "python-levenshtein",
-    "torchmetrics < 0.8.0",
     "sox",
     "librosa",
     "google-cloud-storage",


### PR DESCRIPTION
This pin was in the wrong section as it is used outside of deepspeech. 

This PR exists to CI validate the unpinning.