### PR TITLE
Fix YOLOS integration test error

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "mlflow",
 
     # HF transformers
+    # TODO: unpin this version when patch https://github.com/huggingface/transformers/pull/29353 is released.
     "transformers < 4.38.0",
 
     # an ugly hack to workaround a bug on MacOS which makes PyYAML 5.4.1 unbuildable

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -53,8 +53,8 @@ dependencies = [
     # tracking
     "mlflow",
 
-    # metrics
-    "transformers",
+    # HF transformers
+    "transformers < 4.38.0",
 
     # an ugly hack to workaround a bug on MacOS which makes PyYAML 5.4.1 unbuildable
     # lightning 2.1.2 requires PyYAML >= 5.4 < 8.0 which on MacOS under Python 3.11


### PR DESCRIPTION
Fix YOLOS integration test error by pinning HF transformers library to version less than 4.38.0.

The error is addressed in HF transformers issue [29302](https://github.com/huggingface/transformers/issues/29302), and the fix was merged in PR [29353](https://github.com/huggingface/transformers/pull/29353).