### PR TITLE
Cleanup project dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install
         run: |
           pip3 install --no-compile .
-          pip3 install --no-compile ./library
+          pip3 install --no-compile ./library[extras]
           pip3 install --no-compile ./matrix
 
       - name: Test

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "albumentations<1.4.1",
     "armory-library",
     "adversarial-robustness-toolbox",
+    "tidecv",
 ]
 
 [project.optional-dependencies]

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     # 1.4.1 adds version constraints to scikit-learn and numpy that are incompatible with ART
     "albumentations<1.4.1",
     "armory-library",
+    "adversarial-robustness-toolbox",
 ]
 
 [project.optional-dependencies]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
     "mlflow",
     "numpy",
     "Pillow",
-    "torch >= 2.0.0",
+    "torch",
     "torchmetrics",
-    "torchvision >= 0.15.1",
+    "torchvision",
     "tqdm",
 
     # an ugly hack to workaround a bug on MacOS which makes PyYAML 5.4.1 unbuildable
@@ -44,11 +44,8 @@ extras = [
     "albumentations",
     "matplotlib",
     "pandas",
-    "scikit-learn < 1.2.0", # ART requires scikit-learn >= 0.22.2, < 1.2.0
-    "scipy",                # ART requires scipy >= 1.4.1, < 1.10.1
     "tidecv",
-    # TODO: unpin this version when patch https://github.com/huggingface/transformers/pull/29353 is released.
-    "transformers < 4.38.0",
+    "transformers",
 ]
 
 

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -15,47 +15,17 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 
+# Core dependencies required for general use of Armory
 dependencies = [
-    "loguru",
-    "requests",
-
-    # engine
-    "adversarial-robustness-toolbox == 1.16.0",
     "lightning",
-    "tqdm",
-    "Pillow",                                   # Data dependencies
-    "boto3",                                    # Needed for armory.data.utils
-    "botocore",                                 # Needed for armory.data.utils
-    "ffmpeg-python",                            # Needed for armory.utils.export
-    "pydub",                                    # this is in ART's extra-requires
-    "tidecv",                                   # Needed for TIDE metrics
-    "tensorboardx",
-    "torchmetrics",
-
-    # math
-    # scikit-learn and scipy requirments below are still present in ART v1.16.0
-    "scikit-learn < 1.2.0", # ART requires scikit-learn >= 0.22.2, < 1.2.0
-    "scipy",                # ART requires scipy >= 1.4.1, < 1.10.1
-
-    "numpy",
-    "pandas",
-    "matplotlib",
-
-    # pytorch
-    "torch >= 2.0.0",
-    "torchaudio >= 2.0.1",
-    "torchvision >= 0.15.1",
-
-    # tensorflow
-    "tf-models-official",
-    "tensorflow >= 2.11.0",
-
-    # tracking
+    "loguru",
     "mlflow",
-
-    # HF transformers
-    # TODO: unpin this version when patch https://github.com/huggingface/transformers/pull/29353 is released.
-    "transformers < 4.38.0",
+    "numpy",
+    "Pillow",
+    "torch >= 2.0.0",
+    "torchmetrics",
+    "torchvision >= 0.15.1",
+    "tqdm",
 
     # an ugly hack to workaround a bug on MacOS which makes PyYAML 5.4.1 unbuildable
     # lightning 2.1.2 requires PyYAML >= 5.4 < 8.0 which on MacOS under Python 3.11
@@ -63,6 +33,22 @@ dependencies = [
     # and see if it helps. I'd like to do this as a constraints.txt entry but
     # constraints and --editable are mutually exclusive.
     "PyYAML >= 6",
+]
+
+
+# Dependencies that aren't required for general use of Armory, but may be
+# required according to the specific Armory capabilities being used.
+[project.optional-dependencies]
+extras = [
+    "adversarial-robustness-toolbox",
+    "albumentations",
+    "matplotlib",
+    "pandas",
+    "scikit-learn < 1.2.0", # ART requires scikit-learn >= 0.22.2, < 1.2.0
+    "scipy",                # ART requires scipy >= 1.4.1, < 1.10.1
+    "tidecv",
+    # TODO: unpin this version when patch https://github.com/huggingface/transformers/pull/29353 is released.
+    "transformers < 4.38.0",
 ]
 
 
@@ -74,26 +60,6 @@ Documentation = "https://armory-library.readthedocs.io/en/latest/"
 
 [project.scripts]
 armory-mlflow-server = "charmory.track:server"
-
-
-[project.optional-dependencies]
-extras = [
-    # deepspeech
-    "python-levenshtein",
-    "sox",
-    "librosa",
-    "google-cloud-storage",
-    "transformers",
-
-    # datasets
-    # Handle issue with tensorflow-datasets 4.9.0 not installing correctly
-    # on MacOS, fixed in 4.9.1 - https://github.com/tensorflow/datasets/issues/4852
-    "tensorflow-datasets >= 4.6.0, != 4.9.0",
-    "protobuf",
-
-    # datasets-builder
-    "apache-beam >= 2.22.0",
-]
 
 
 [build-system]


### PR DESCRIPTION
- removes old dependencies from GARD
- moves all non-essential dependencies to optional in armory-library
- removes all unnecessary version pinning

closes #125 