### PR TITLE
156 import failure with setuptools 70.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -44,10 +44,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -98,10 +98,10 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -124,10 +124,10 @@ jobs:
       - integration-tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -138,7 +138,7 @@ jobs:
         run: task docs
 
       - name: Upload Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: armory-library-docs
           path: public
@@ -159,10 +159,10 @@ jobs:
           - matrix
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -175,7 +175,7 @@ jobs:
         run: cd ${{ matrix.package }} && hatch build --clean --target wheel
 
       - name: Upload Wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: armory-${{ matrix.package }}-wheel
           path: ${{ matrix.package }}/dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
           - examples
     steps:
       - name: Setup Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Checkout Armory with full depth (for tags and SCM)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.client_payload.branch }}

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     # and see if it helps. I'd like to do this as a constraints.txt entry but
     # constraints and --editable are mutually exclusive.
     "PyYAML >= 6",
+
+    # Temporary workaround since ART imports pkg_resources.packaging but
+    # setuptools 70.0.0 removed that module from pkg_resources
+    "setuptools<70.0.0",
 ]
 
 


### PR DESCRIPTION
Pins setuptools to <70 as a temporary workaround until ART fixes their import.

Also bumps the version on all the GitHub actions to get rid of the node 16-vs-20 warnings in GitHub.