### PR TITLE
Downgrade Pillow version < 11.2.1 for HF dataset filtering bug

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "lightning",
     "mlflow",
     "numpy",
-    "Pillow",
+    "Pillow < 11.2.1",
     "rich",
     "torch",
     "torchmetrics",


### PR DESCRIPTION
Pillow version 11.2.1 introduced bug when filtering HF Food101 dataset -- limit Pillow to versions < 11.2.1.